### PR TITLE
Improved testability with app instance and os.environ

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
-CLIENT_ID="548578149714-bro16fg8ta1eme4kshlrtmi65gutino4.apps.googleusercontent.com"
-CLIENT_SECRET="q00Pjg1HLc3Yb9q44d-NgXUu"
+GA_CLIENT_ID="548578149714-bro16fg8ta1eme4kshlrtmi65gutino4.apps.googleusercontent.com"
+GA_CLIENT_SECRET="q00Pjg1HLc3Yb9q44d-NgXUu"
 REDIRECT_URI="http://127.0.0.1:5000/callback"
 CONFIG_ROOT_DIR="."
 GA_CONFIG_FILENAME="ga_config.json"

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,4 @@
 GA_CLIENT_ID="548578149714-bro16fg8ta1eme4kshlrtmi65gutino4.apps.googleusercontent.com"
 GA_CLIENT_SECRET="q00Pjg1HLc3Yb9q44d-NgXUu"
-REDIRECT_URI="http://127.0.0.1:5000/callback"
-CONFIG_ROOT_DIR="."
-GA_CONFIG_FILENAME="ga_config.json"
+GA_REDIRECT_URI="http://127.0.0.1:5000/callback"
+RUNNING_STATE_DIR="."

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn -b 0.0.0.0:5000 -w 8 bizarro:app
+web: gunicorn -b 0.0.0.0:5000 -w 8 bizarro.wsgi:app
 gapi_access_token: PYTHONUNBUFFERED=true python -m bizarro.google_access_token_update --hourly

--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -5,17 +5,17 @@ from logging import getLogger, DEBUG
 from . import repo_functions, edit_functions, jekyll_functions
 
 def create_app():
-	app = Flask(__name__)
-	app.secret_key = 'boop'
-	app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
-	app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
-	app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')
-	app.config['SINGLE_USER'] = bool(environ.get('SINGLE_USER', False))
-	app.config['default_branch'] = 'master'
+    app = Flask(__name__)
+    app.secret_key = 'boop'
+    app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
+    app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
+    app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')
+    app.config['SINGLE_USER'] = bool(environ.get('SINGLE_USER', False))
+    app.config['default_branch'] = 'master'
 
-	# attach routes and custom error pages here
+    # attach routes and custom error pages here
 
-	return app
+    return app
 
 # @app.before_first_request
 # def before_first_request():
@@ -24,5 +24,5 @@ def create_app():
 #     if current_app.debug:
 #         getLogger('bizarro').setLevel(DEBUG)
 
-# from . import views
+from . import views
 

--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -1,12 +1,16 @@
-from os import environ
 from flask import Blueprint, current_app, Flask
 from logging import getLogger, DEBUG
 
 bizarro = Blueprint('bizarro', __name__, template_folder='templates')
 
-def create_app():
+def create_app(environ):
     app = Flask(__name__, static_folder='static')
     app.secret_key = 'boop'
+    app.config['CONFIG_ROOT_DIR'] = environ['CONFIG_ROOT_DIR']
+    app.config['GA_CONFIG_FILENAME'] = environ['GA_CONFIG_FILENAME']
+    app.config['GA_CLIENT_ID'] = environ['GA_CLIENT_ID']
+    app.config['GA_CLIENT_SECRET'] = environ['GA_CLIENT_SECRET']
+    app.config['REDIRECT_URI'] = environ.get('REDIRECT_URI', 'http://127.0.0.1:5000/callback')
     app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
     app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
     app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')

--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -1,11 +1,11 @@
 from os import environ
-from flask import Flask, current_app
+from flask import Blueprint, current_app, Flask
 from logging import getLogger, DEBUG
 
-from . import repo_functions, edit_functions, jekyll_functions
+bizarro = Blueprint('bizarro', __name__, template_folder='templates')
 
 def create_app():
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder='static')
     app.secret_key = 'boop'
     app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
     app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
@@ -14,6 +14,7 @@ def create_app():
     app.config['default_branch'] = 'master'
 
     # attach routes and custom error pages here
+    app.register_blueprint(bizarro)
 
     return app
 

--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -6,11 +6,10 @@ bizarro = Blueprint('bizarro', __name__, template_folder='templates')
 def create_app(environ):
     app = Flask(__name__, static_folder='static')
     app.secret_key = 'boop'
-    app.config['CONFIG_ROOT_DIR'] = environ['CONFIG_ROOT_DIR']
-    app.config['GA_CONFIG_FILENAME'] = environ['GA_CONFIG_FILENAME']
+    app.config['RUNNING_STATE_DIR'] = environ['RUNNING_STATE_DIR']
     app.config['GA_CLIENT_ID'] = environ['GA_CLIENT_ID']
     app.config['GA_CLIENT_SECRET'] = environ['GA_CLIENT_SECRET']
-    app.config['REDIRECT_URI'] = environ.get('REDIRECT_URI', 'http://127.0.0.1:5000/callback')
+    app.config['GA_REDIRECT_URI'] = environ.get('GA_REDIRECT_URI', 'http://127.0.0.1:5000/callback')
     app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
     app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
     app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')

--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -4,19 +4,25 @@ from logging import getLogger, DEBUG
 
 from . import repo_functions, edit_functions, jekyll_functions
 
-app = Flask(__name__)
-app.secret_key = 'boop'
-app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
-app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
-app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')
-app.config['SINGLE_USER'] = bool(environ.get('SINGLE_USER', False))
-app.config['default_branch'] = 'master'
+def create_app():
+	app = Flask(__name__)
+	app.secret_key = 'boop'
+	app.config['WORK_PATH'] = environ.get('WORK_PATH', '.')
+	app.config['REPO_PATH'] = environ.get('REPO_PATH', 'sample-site')
+	app.config['BROWSERID_URL'] = environ.get('BROWSERID_URL', 'http://127.0.0.1:5000')
+	app.config['SINGLE_USER'] = bool(environ.get('SINGLE_USER', False))
+	app.config['default_branch'] = 'master'
 
-@app.before_first_request
-def before_first_request():
-    '''
-    '''
-    if current_app.debug:
-        getLogger('bizarro').setLevel(DEBUG)
+	# attach routes and custom error pages here
 
-from . import views
+	return app
+
+# @app.before_first_request
+# def before_first_request():
+#     '''
+#     '''
+#     if current_app.debug:
+#         getLogger('bizarro').setLevel(DEBUG)
+
+# from . import views
+

--- a/bizarro/google_access_token_update.py
+++ b/bizarro/google_access_token_update.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 Logger = getLogger('bizarro.google_access_token_update')
 
-from .google_api_functions import get_new_access_token
+from .google_api_functions import get_new_access_token, GA_CONFIG_FILENAME
 import json
 import os
 import argparse, traceback, sys
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     '''
     while True:
         try:
-            ga_config_path = os.path.join(os.environ.get('CONFIG_ROOT_DIR'), os.environ.get('GA_CONFIG_FILENAME'))
+            ga_config_path = os.path.join(os.environ.get('RUNNING_STATE_DIR'), GA_CONFIG_FILENAME)
             with open(ga_config_path) as infile:
                 ga_config = json.load(infile)
             get_new_access_token(ga_config['refresh_token'])

--- a/bizarro/google_access_token_update.py
+++ b/bizarro/google_access_token_update.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     '''
     while True:
         try:
-            ga_config_path = os.path.join(os.environ.get('RUNNING_STATE_DIR'), GA_CONFIG_FILENAME)
+            ga_config_path = os.path.join(os.environ['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
             with open(ga_config_path) as infile:
                 ga_config = json.load(infile)
             get_new_access_token(ga_config['refresh_token'])

--- a/bizarro/google_api_functions.py
+++ b/bizarro/google_api_functions.py
@@ -10,6 +10,8 @@ import json
 from datetime import date, timedelta
 from re import sub
 
+GA_CONFIG_FILENAME = 'ga_config.json'
+
 def authorize_google():
     ''' Authorize google via oauth2
     '''
@@ -21,7 +23,7 @@ def authorize_google():
     session['state'] = state
 
 
-    query_string = urlencode(dict(client_id=current_app.config['GA_CLIENT_ID'], redirect_uri=current_app.config['REDIRECT_URI'],
+    query_string = urlencode(dict(client_id=current_app.config['GA_CLIENT_ID'], redirect_uri=current_app.config['GA_REDIRECT_URI'],
                                   scope='openid profile https://www.googleapis.com/auth/analytics', state=state, response_type='code',
                                   access_type='offline', approval_prompt='force'))
     return redirect('https://accounts.google.com/o/oauth2/auth' + '?' + query_string)
@@ -43,7 +45,7 @@ def callback_google(state, code, callback_uri):
         raise Exception()
     access = json.loads(resp.content)
 
-    ga_config_path = os.path.join(current_app.config['CONFIG_ROOT_DIR'], current_app.config['GA_CONFIG_FILENAME'])
+    ga_config_path = os.path.join(current_app.config['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
     with open(ga_config_path) as infile:
         ga_config = json.load(infile)
 
@@ -73,7 +75,7 @@ def get_new_access_token(refresh_token):
     access = json.loads(resp.content)
 
     # load the config json
-    ga_config_path = os.path.join(current_app.config['CONFIG_ROOT_DIR'], current_app.config['GA_CONFIG_FILENAME'])
+    ga_config_path = os.path.join(current_app.config['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
     with open(ga_config_path) as infile:
         ga_config = json.load(infile)
     # change the value of the access token
@@ -97,7 +99,7 @@ def get_ga_page_path_pattern(page_path, project_domain):
 def fetch_google_analytics_for_page(config, page_path, access_token):
     ''' Get stats for a particular page
     '''
-    ga_config_path = os.path.join(config['CONFIG_ROOT_DIR'], config['GA_CONFIG_FILENAME'])
+    ga_config_path = os.path.join(config['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
     with open(ga_config_path) as infile:
         ga_config = json.load(infile)
     ga_project_domain = ga_config['project_domain']

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -12,7 +12,8 @@ from git.cmd import GitCommandError
 from requests import post
 from flask import redirect, request, Response, render_template, session, current_app, flash, Blueprint
 
-from . import create_app, repo_functions, edit_functions
+from . import bizarro as app
+from . import repo_functions, edit_functions
 from .jekyll_functions import load_jekyll_doc, build_jekyll_site, load_languages
 from .view_functions import (
   branch_name2path, branch_var2name, get_repo, path_type, name_branch, dos2unix,

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -20,7 +20,8 @@ from .view_functions import (
   login_required, synch_required, synched_checkout_required, is_editable, sorted_paths,
   directory_paths, should_redirect, make_redirect
   )
-from .google_api_functions import authorize_google, callback_google, fetch_google_analytics_for_page
+from .google_api_functions import authorize_google, callback_google, fetch_google_analytics_for_page, GA_CONFIG_FILENAME
+
 
 import posixpath
 import json
@@ -275,7 +276,7 @@ def branch_edit(branch, path=None):
         view_path = join('/tree/%s/view' % branch_name2path(branch), path)
         app_authorized = False
 
-        ga_config_path = posixpath.join(current_app.config['CONFIG_ROOT_DIR'], current_app.config['GA_CONFIG_FILENAME'])
+        ga_config_path = posixpath.join(current_app.config['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
         analytics_dict = {}
         if isfile(ga_config_path):
             with open(ga_config_path) as infile:

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -10,9 +10,9 @@ from glob import glob
 from git import Repo
 from git.cmd import GitCommandError
 from requests import post
-from flask import redirect, request, Response, render_template, session, current_app, flash
+from flask import redirect, request, Response, render_template, session, current_app, flash, Blueprint
 
-from . import app, repo_functions, edit_functions
+from . import create_app, repo_functions, edit_functions
 from .jekyll_functions import load_jekyll_doc, build_jekyll_site, load_languages
 from .view_functions import (
   branch_name2path, branch_var2name, get_repo, path_type, name_branch, dos2unix,

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -275,7 +275,7 @@ def branch_edit(branch, path=None):
         view_path = join('/tree/%s/view' % branch_name2path(branch), path)
         app_authorized = False
 
-        ga_config_path = posixpath.join(environ.get('CONFIG_ROOT_DIR'), environ.get('GA_CONFIG_FILENAME'))
+        ga_config_path = posixpath.join(current_app.config['CONFIG_ROOT_DIR'], current_app.config['GA_CONFIG_FILENAME'])
         analytics_dict = {}
         if isfile(ga_config_path):
             with open(ga_config_path) as infile:
@@ -283,7 +283,7 @@ def branch_edit(branch, path=None):
 
             if ga_config['access_token'] not in [u'', None]:
                 app_authorized = True
-                analytics_dict = fetch_google_analytics_for_page(path, ga_config['access_token'])
+                analytics_dict = fetch_google_analytics_for_page(current_app.config, path, ga_config['access_token'])
 
         kwargs = dict(dict(branch=branch, safe_branch=safe_branch,
                       body=body, hexsha=c.hexsha, url_slug=url_slug,

--- a/bizarro/wsgi.py
+++ b/bizarro/wsgi.py
@@ -1,0 +1,4 @@
+from os import environ
+from . import create_app
+
+app = create_app(environ)

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-from bizarro import app
-
+from bizarro import create_app
 if __name__ == '__main__':
+    app = create_app()
     app.run(debug=True)

--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 from bizarro import create_app
+from os import environ
 if __name__ == '__main__':
-    app = create_app()
+    app = create_app(environ)
     app.run(debug=True)

--- a/test/test.py
+++ b/test/test.py
@@ -830,14 +830,18 @@ class TestRepo (TestCase):
 class TestGoogleApiFunctions (TestCase):
 
     def setUp(self):
-        environ['CLIENT_ID'] = 'client_id'
-        environ['CLIENT_SECRET'] = 'meow_secret'
+        app_args = {}
+        app_args['GA_CLIENT_ID'] = 'client_id'
+        app_args['GA_CLIENT_SECRET'] = 'meow_secret'
 
-        ga_config_path = mkdtemp(prefix='bizarro-config-')
-        self.app = create_app()
-        self.app.config['CONFIG_PATH'] = ga_config_path
-        environ['CONFIG_ROOT_DIR'] = ga_config_path
-        environ['GA_CONFIG_FILENAME'] = "ga_config.json"
+        self.ga_config_dir = mkdtemp(prefix='bizarro-config-')
+        app_args['CONFIG_ROOT_DIR'] = self.ga_config_dir
+        app_args['GA_CONFIG_FILENAME'] = "ga_config.json"
+        app_args['CONFIG_PATH'] = self.ga_config_dir
+
+        self.app = create_app(app_args)
+
+        ga_config_path = join(self.ga_config_dir, app_args['GA_CONFIG_FILENAME'])
 
         # write a tmp config file
         ga_config = {
@@ -846,12 +850,11 @@ class TestGoogleApiFunctions (TestCase):
             "profile_id": "12345678",
             "project_domain": ""
         }
-        ga_config_path = os.path.join(environ['CONFIG_ROOT_DIR'], environ['GA_CONFIG_FILENAME'])
         with open(ga_config_path, 'w') as outfile:
             json.dump(ga_config, outfile, indent=2, ensure_ascii=False)
 
     def tearDown(self):
-        rmtree(self.app.config['CONFIG_PATH'])
+        rmtree(self.ga_config_dir)
 
     def mock_successful_get_new_access_token(self, url, request):
         if 'https://accounts.google.com/o/oauth2/token' in url.geturl():
@@ -883,7 +886,7 @@ class TestGoogleApiFunctions (TestCase):
             with HTTMock(self.mock_successful_get_new_access_token):
                 google_api_functions.get_new_access_token('meowser_refresh_token')
 
-                ga_config_path = os.path.join(environ['CONFIG_ROOT_DIR'], environ['GA_CONFIG_FILENAME'])
+                ga_config_path = os.path.join(self.app.config['CONFIG_ROOT_DIR'], self.app.config['GA_CONFIG_FILENAME'])
                 with open(ga_config_path) as infile:
                     ga_config = json.load(infile)
 
@@ -916,7 +919,7 @@ class TestGoogleApiFunctions (TestCase):
         ''' Verify that an authorized analytics response is handled correctly
         '''
         with HTTMock(self.mock_google_analytics_authorized_response):
-            analytics_dict = google_api_functions.fetch_google_analytics_for_page(u'index.html', 'meowser_token')
+            analytics_dict = google_api_functions.fetch_google_analytics_for_page(self.app.config, u'index.html', 'meowser_token')
             self.assertEqual(analytics_dict['page_views'], u'24')
             self.assertEqual(analytics_dict['average_time_page'], u'67')
 
@@ -924,30 +927,47 @@ class TestGoogleApiFunctions (TestCase):
         ''' Verify that an unauthorized analytics response is handled correctly
         '''
         with HTTMock(self.mock_google_analytics_unauthorized_response):
-            analytics_dict = google_api_functions.fetch_google_analytics_for_page(u'index.html', 'meowser_token')
+            analytics_dict = google_api_functions.fetch_google_analytics_for_page(self.app.config, u'index.html', 'meowser_token')
             self.assertEqual(analytics_dict, {})
+
+class TestAppConfig (TestCase):
+
+    def test_missing_values(self):
+        self.assertRaises(KeyError, lambda: create_app({}))
+
+    def test_present_values(self):
+        app_config = {}
+        app_config['CONFIG_ROOT_DIR'] = 'Yo'
+        app_config['GA_CONFIG_FILENAME'] = 'Yo'
+        app_config['GA_CLIENT_ID'] = 'Yo'
+        app_config['GA_CLIENT_SECRET'] = 'Yo'
+        create_app(app_config)
 
 class TestApp (TestCase):
 
     def setUp(self):
-        work_path = mkdtemp(prefix='bizarro-repo-clones-')
+        self.work_path = mkdtemp(prefix='bizarro-repo-clones-')
 
         repo_path = os.path.dirname(os.path.abspath(__file__)) + '/test-app.git'
-        temp_repo_dir = mkdtemp(prefix='bizarro-root')
-        temp_repo_path = temp_repo_dir + '/test-app.git'
+        self.temp_repo_dir = mkdtemp(prefix='bizarro-root')
+        temp_repo_path = self.temp_repo_dir + '/test-app.git'
         copytree(repo_path, temp_repo_path)
 
-        app = create_app()
+        app_args = {}
 
-        app.config['WORK_PATH'] = work_path
-        app.config['REPO_PATH'] = temp_repo_path
-        environ['CLIENT_ID'] = 'client_id'
-        environ['CLIENT_SECRET'] = 'meow_secret'
+        app_args['GA_CLIENT_ID'] = 'client_id'
+        app_args['GA_CLIENT_SECRET'] = 'meow_secret'
 
-        ga_config_path = mkdtemp(prefix='bizarro-config-')
-        app.config['CONFIG_PATH'] = ga_config_path
-        environ['CONFIG_ROOT_DIR'] = ga_config_path
-        environ['GA_CONFIG_FILENAME'] = "ga_config.json"
+        self.ga_config_dir = mkdtemp(prefix='bizarro-config-')
+        app_args['CONFIG_PATH'] = self.ga_config_dir
+        app_args['CONFIG_ROOT_DIR'] = self.ga_config_dir
+        app_args['GA_CONFIG_FILENAME'] = "ga_config.json"
+        app_args['WORK_PATH'] = self.work_path
+        app_args['REPO_PATH'] = temp_repo_path
+
+        ga_config_path = join(self.ga_config_dir, app_args['GA_CONFIG_FILENAME'])
+
+        app = create_app(app_args)
 
         # write a tmp config file
         ga_config = {
@@ -956,19 +976,18 @@ class TestApp (TestCase):
             "profile_id": "12345678",
             "project_domain": ""
         }
-        ga_config_path = os.path.join(environ['CONFIG_ROOT_DIR'], environ['GA_CONFIG_FILENAME'])
         with open(ga_config_path, 'w') as outfile:
             json.dump(ga_config, outfile, indent=2, ensure_ascii=False)
 
         random.choice = MagicMock(return_value="P")
 
-        self.app = app.test_client()
-        self._app = app
+        self.server = app.test_client()
+        self.app = app
 
     def tearDown(self):
-        rmtree(self._app.config['WORK_PATH'])
-        rmtree(self._app.config['REPO_PATH'])
-        rmtree(self._app.config['CONFIG_PATH'])
+        rmtree(self.work_path)
+        rmtree(self.temp_repo_dir)
+        rmtree(self.ga_config_dir)
 
 
     def persona_verify(self, url, request):
@@ -1015,47 +1034,47 @@ class TestApp (TestCase):
     def test_login(self):
         ''' Check basic log in / log out flow without talking to Persona.
         '''
-        response = self.app.get('/')
+        response = self.server.get('/')
         self.assertFalse('user@example.com' in response.data)
 
         with HTTMock(self.persona_verify):
-            response = self.app.post('/sign-in', data={'email': 'user@example.com'})
+            response = self.server.post('/sign-in', data={'email': 'user@example.com'})
             self.assertEquals(response.status_code, 200)
 
-        response = self.app.get('/')
+        response = self.server.get('/')
         self.assertTrue('user@example.com' in response.data)
 
-        response = self.app.post('/sign-out')
+        response = self.server.post('/sign-out')
         self.assertEquals(response.status_code, 200)
 
-        response = self.app.get('/')
+        response = self.server.get('/')
         self.assertFalse('user@example.com' in response.data)
 
     def test_branches(self):
         ''' Check basic branching functionality.
         '''
         with HTTMock(self.persona_verify):
-            self.app.post('/sign-in', data={'email': 'user@example.com'})
+            self.server.post('/sign-in', data={'email': 'user@example.com'})
 
-        response = self.app.post('/start', data={'branch': 'do things'},
+        response = self.server.post('/start', data={'branch': 'do things'},
                                  follow_redirects=True)
         self.assertTrue('user@example.com/do-things' in response.data)
 
         with HTTMock(self.mock_google_analytics):
-            response = self.app.post('/tree/user@example.com%252Fdo-things/edit/',
+            response = self.server.post('/tree/user@example.com%252Fdo-things/edit/',
                                      data={'action': 'add', 'path': 'hello.html'},
                                      follow_redirects=True)
 
             self.assertEquals(response.status_code, 200)
 
-            response = self.app.get('/tree/user@example.com%252Fdo-things/edit/')
+            response = self.server.get('/tree/user@example.com%252Fdo-things/edit/')
 
             self.assertTrue('hello.html' in response.data)
 
-            response = self.app.get('/tree/user@example.com%252Fdo-things/edit/hello.html')
+            response = self.server.get('/tree/user@example.com%252Fdo-things/edit/hello.html')
             hexsha = search(r'<input name="hexsha" value="(\w+)"', response.data).group(1)
 
-            response = self.app.post('/tree/user@example.com%252Fdo-things/save/hello.html',
+            response = self.server.post('/tree/user@example.com%252Fdo-things/save/hello.html',
                                      data={'layout': 'multi', 'hexsha': hexsha,
                                            'en-title': 'Greetings', 'en-body': 'Hello world.\n',
                                            'fr-title': '', 'fr-body': '',
@@ -1080,15 +1099,15 @@ class TestApp (TestCase):
             when we successfully auth with google
         '''
         with HTTMock(self.persona_verify):
-            self.app.post('/sign-in', data={'email': 'erica@example.com'})
+            self.server.post('/sign-in', data={'email': 'erica@example.com'})
 
         with HTTMock(self.mock_google_authorization):
-            self.app.post('/authorize')
+            self.server.post('/authorize')
 
         with HTTMock(self.mock_successful_google_callback):
-            response = self.app.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
+            response = self.server.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
 
-        ga_config_path = os.path.join(environ['CONFIG_ROOT_DIR'], environ['GA_CONFIG_FILENAME'])
+        ga_config_path = os.path.join(self.app.config['CONFIG_ROOT_DIR'], self.app.config['GA_CONFIG_FILENAME'])
         with open(ga_config_path) as infile:
             ga_config = json.load(infile)
 
@@ -1102,13 +1121,13 @@ class TestApp (TestCase):
             when we fail to auth with google
         '''
         with HTTMock(self.persona_verify):
-            self.app.post('/sign-in', data={'email': 'erica@example.com'})
+            self.server.post('/sign-in', data={'email': 'erica@example.com'})
 
         with HTTMock(self.mock_google_authorization):
-            self.app.post('/authorize')
+            self.server.post('/authorize')
 
         with HTTMock(self.mock_failed_google_callback):
-            response = self.app.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
+            response = self.server.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
 
         self.assertTrue('authorization-failed' in response.location)
 

--- a/test/test.py
+++ b/test/test.py
@@ -835,13 +835,12 @@ class TestGoogleApiFunctions (TestCase):
         app_args['GA_CLIENT_SECRET'] = 'meow_secret'
 
         self.ga_config_dir = mkdtemp(prefix='bizarro-config-')
-        app_args['CONFIG_ROOT_DIR'] = self.ga_config_dir
-        app_args['GA_CONFIG_FILENAME'] = "ga_config.json"
+        app_args['RUNNING_STATE_DIR'] = self.ga_config_dir
         app_args['CONFIG_PATH'] = self.ga_config_dir
 
         self.app = create_app(app_args)
 
-        ga_config_path = join(self.ga_config_dir, app_args['GA_CONFIG_FILENAME'])
+        ga_config_path = join(self.ga_config_dir, google_api_functions.GA_CONFIG_FILENAME)
 
         # write a tmp config file
         ga_config = {
@@ -886,7 +885,7 @@ class TestGoogleApiFunctions (TestCase):
             with HTTMock(self.mock_successful_get_new_access_token):
                 google_api_functions.get_new_access_token('meowser_refresh_token')
 
-                ga_config_path = os.path.join(self.app.config['CONFIG_ROOT_DIR'], self.app.config['GA_CONFIG_FILENAME'])
+                ga_config_path = os.path.join(self.app.config['RUNNING_STATE_DIR'], google_api_functions.GA_CONFIG_FILENAME)
                 with open(ga_config_path) as infile:
                     ga_config = json.load(infile)
 
@@ -937,8 +936,7 @@ class TestAppConfig (TestCase):
 
     def test_present_values(self):
         app_config = {}
-        app_config['CONFIG_ROOT_DIR'] = 'Yo'
-        app_config['GA_CONFIG_FILENAME'] = 'Yo'
+        app_config['RUNNING_STATE_DIR'] = 'Yo'
         app_config['GA_CLIENT_ID'] = 'Yo'
         app_config['GA_CLIENT_SECRET'] = 'Yo'
         create_app(app_config)
@@ -960,12 +958,11 @@ class TestApp (TestCase):
 
         self.ga_config_dir = mkdtemp(prefix='bizarro-config-')
         app_args['CONFIG_PATH'] = self.ga_config_dir
-        app_args['CONFIG_ROOT_DIR'] = self.ga_config_dir
-        app_args['GA_CONFIG_FILENAME'] = "ga_config.json"
+        app_args['RUNNING_STATE_DIR'] = self.ga_config_dir
         app_args['WORK_PATH'] = self.work_path
         app_args['REPO_PATH'] = temp_repo_path
 
-        ga_config_path = join(self.ga_config_dir, app_args['GA_CONFIG_FILENAME'])
+        ga_config_path = join(self.ga_config_dir, google_api_functions.GA_CONFIG_FILENAME)
 
         app = create_app(app_args)
 
@@ -1107,7 +1104,7 @@ class TestApp (TestCase):
         with HTTMock(self.mock_successful_google_callback):
             response = self.server.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
 
-        ga_config_path = os.path.join(self.app.config['CONFIG_ROOT_DIR'], self.app.config['GA_CONFIG_FILENAME'])
+        ga_config_path = os.path.join(self.app.config['RUNNING_STATE_DIR'], google_api_functions.GA_CONFIG_FILENAME)
         with open(ga_config_path) as infile:
             ga_config = json.load(infile)
 


### PR DESCRIPTION
Removed most uses of `os.environ` for config variables, added [`bizarro.create_app()` factory function](http://flask.pocoo.org/docs/0.10/patterns/appfactories/), added [Flask Blueprint support](http://flask.pocoo.org/docs/0.10/blueprints/), and made initial setup fail catastrophically when required variables are missing.

Closes #108.