### PR TITLE
Add more details to docs, tweak .env defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ Install
    [Python Virtual Environments](https://github.com/codeforamerica/howto/blob/master/Python-Virtualenv.md)
    to prepare your Python development space.
 
-2. You will need a bare Github repository in the directory `sample-site`
-   (this will become configurable in the future).
+2. Install the project requirements: `pip install -r requirements.txt`
 
-3. copy env.sample to .env
+3. You will need a bare Github repository in the directory `sample-site` with an initial empty commit
+   (this will become configurable in the future):
 
-4. Run the app with [Foreman](http://ddollar.github.com/foreman):
+ + `cd sample-site`
+ + `git init`
+ + `git commit --allow-empty -m "First commit"`
+
+4. copy env.sample to .env
+
+5. Run the app with [Foreman](http://ddollar.github.com/foreman):
 
         $ foreman run python run.py
 

--- a/env.sample
+++ b/env.sample
@@ -1,25 +1,28 @@
-;    # Required for a directory where bizarro can stash state files.
-;    RUNNING_STATE_DIR="."
-;    
-;    # Optional directory names for Git repositories.
-;    REPO_PATH="{Bare repository directory path}"
-;    WORK_PATH="{Working directory path}"
-;    
-;    # Optional domain name for use by Browser ID.
-;    BROWSERID_URL="{Browser ID domain name}"
-;    
-;    # Optional URL to authorization CSV.
-;    AUTH_CSV_URL="{CSV export URL, usually Google spreadsheet}"
-;    
-;    # Required for Google Analytics setup.
-;    GA_CLIENT_ID="{Google OAuth client ID}"
-;    GA_CLIENT_SECRET="{Google OAuth client secret}"
-;    GA_REDIRECT_URI="http://127.0.0.1:5000/callback"
-;    
-;    # Optional for setup-script.py Google Docs preparation.
-;    GDOCS_CLIENT_ID="{Google OAuth client ID}"
-;    GDOCS_CLIENT_SECRET="{Google OAuth client secret}"
-;    
-;    # Optional for setup-script.py Github repository preparation.
-;    GITHUB_CLIENT_ID="{Github OAuth client ID}"
-;    GITHUB_CLIENT_SECRET="{Github OAuth client secret}"
+# Required for a directory where bizarro can stash state files.
+RUNNING_STATE_DIR="."
+
+# Optional directory names for Git repositories.
+# REPO_PATH="{Bare repository directory path}"
+# WORK_PATH="{Working directory path}"
+
+# Optional domain name for use by Browser ID.
+# BROWSERID_URL="{Browser ID domain name}"
+
+# Optional URL to authorization CSV.
+# AUTH_CSV_URL="{CSV export URL, usually Google spreadsheet}"
+
+# Required for Google Analytics setup.
+GA_CLIENT_ID="{Google OAuth client ID}"
+GA_CLIENT_SECRET="{Google OAuth client secret}"
+GA_REDIRECT_URI="http://127.0.0.1:5000/callback"
+
+# Optional for setup-script.py Google Docs preparation.
+GDOCS_CLIENT_ID="{Google OAuth client ID}"
+GDOCS_CLIENT_SECRET="{Google OAuth client secret}"
+
+# Optional for setup-script.py Github repository preparation.
+GITHUB_CLIENT_ID="{Github OAuth client ID}"
+GITHUB_CLIENT_SECRET="{Github OAuth client secret}"
+
+# Optional URL base for live running website.
+LIVE_SITE_URL="http://127.0.0.1:5001/"


### PR DESCRIPTION
* Add step to README to help out Python newbies like me.
* Take semicolons out of env.sample, they were throwing errors during setup.
* Tweak env.sample defaults, uncommented config vars threw errors in setup.