### PR TITLE
Separate publish service

### DIFF
--- a/bizarro/__init__.py
+++ b/bizarro/__init__.py
@@ -73,6 +73,7 @@ def create_app(environ):
     app.config['SINGLE_USER'] = bool(environ.get('SINGLE_USER', False))
     app.config['AUTH_DATA_HREF'] = environ.get('AUTH_DATA_HREF', 'data/authentication.csv')
     app.config['LIVE_SITE_URL'] = environ.get('LIVE_SITE_URL', 'http://127.0.0.1:5001/')
+    app.config['PUBLISH_SERVICE_URL'] = environ.get('PUBLISH_SERVICE_URL', False)
     app.config['default_branch'] = 'master'
     
     # If no live site URL was provided, we'll use Apache to make our own.

--- a/bizarro/publish/__init__.py
+++ b/bizarro/publish/__init__.py
@@ -4,31 +4,37 @@ logger = getLogger('bizarro.publish')
 from os import mkdir
 from os.path import join
 from tempfile import mkdtemp
+from urlparse import urljoin
 from shutil import rmtree
+from io import BytesIO
 
 from flask import Blueprint, Flask
 from logging import getLogger, DEBUG
 
 from .functions import process_local_commit
 
-def announce_commit(build_url, repo, commit_sha):
+def announce_commit(base_href, repo, commit_ref):
     '''
     '''
+    build_url = urljoin(base_href, '/checkouts/{}.zip'.format(commit_ref))
+    
     raise Exception(build_url)
 
-def retrieve_commit_build(running_dir, repo, commit_sha):
+def retrieve_commit_checkout(running_dir, repo, commit_ref):
     '''
     '''
-    logger.debug('Retrieve commit {}'.format(commit_sha))
+    logger.debug('Retrieve commit {}'.format(commit_ref))
     
     try:
         working_dir = mkdtemp()
         archive_path = join(working_dir, 'archive.zip')
         
         with open(archive_path, 'w') as file:
-            repo.archive(file, commit_sha, format='zip')
+            repo.archive(file, commit_ref, format='zip')
         
-        _, bytes = process_local_commit(archive_path)
+        with open(archive_path, 'r') as file:
+            bytes = BytesIO(file.read())
+        
         return bytes
         
     except Exception as e:
@@ -38,19 +44,19 @@ def retrieve_commit_build(running_dir, repo, commit_sha):
     finally:
         rmtree(working_dir)
 
-def release_commit(running_dir, repo, commit_sha):
+def release_commit(running_dir, repo, commit_ref):
     '''
     '''
-    logger.debug('Release commit {}'.format(commit_sha))
+    logger.debug('Release commit {}'.format(commit_ref))
     
     try:
         working_dir = mkdtemp()
         archive_path = join(working_dir, 'archive.zip')
         
         with open(archive_path, 'w') as file:
-            repo.archive(file, commit_sha, format='zip')
+            repo.archive(file, commit_ref, format='zip')
         
-        zip, bytes = process_local_commit(archive_path)
+        zip = process_local_commit(archive_path)
         extract_dir = join(running_dir, 'master')
         
         try:

--- a/bizarro/publish/__init__.py
+++ b/bizarro/publish/__init__.py
@@ -11,6 +11,33 @@ from logging import getLogger, DEBUG
 
 from .functions import process_local_commit
 
+def announce_commit(build_url, repo, commit_sha):
+    '''
+    '''
+    raise Exception(build_url)
+
+def retrieve_commit_build(running_dir, repo, commit_sha):
+    '''
+    '''
+    logger.debug('Retrieve commit {}'.format(commit_sha))
+    
+    try:
+        working_dir = mkdtemp()
+        archive_path = join(working_dir, 'archive.zip')
+        
+        with open(archive_path, 'w') as file:
+            repo.archive(file, commit_sha, format='zip')
+        
+        _, bytes = process_local_commit(archive_path)
+        return bytes
+        
+    except Exception as e:
+        print e
+        logger.warning(e)
+
+    finally:
+        rmtree(working_dir)
+
 def release_commit(running_dir, repo, commit_sha):
     '''
     '''
@@ -23,7 +50,7 @@ def release_commit(running_dir, repo, commit_sha):
         with open(archive_path, 'w') as file:
             repo.archive(file, commit_sha, format='zip')
         
-        zip = process_local_commit(archive_path)
+        zip, bytes = process_local_commit(archive_path)
         extract_dir = join(running_dir, 'master')
         
         try:

--- a/bizarro/publish/functions.py
+++ b/bizarro/publish/functions.py
@@ -14,40 +14,40 @@ from requests import get
 from ..jekyll_functions import build_jekyll_site
 
 def process_local_commit(archive_path):
-    '''
+    ''' Return ZipFile and underlying file object.
     '''
     try:
         working_dir = mkdtemp()
         checkout_dir = extract_local_commit(working_dir, archive_path)
         built_dir = build_jekyll_site(checkout_dir)
-        zip = archive_commit(built_dir)
+        zip, bytes = archive_commit(built_dir)
         
     except Exception as e:
         logger.warning(e)
-        zip = None
+        zip, bytes = None, None
 
     finally:
         rmtree(working_dir)
     
-    return zip
+    return zip, bytes
 
 def process_remote_commit(commit_url, commit_sha):
-    '''
+    ''' Return ZipFile and underlying file object.
     '''
     try:
         working_dir = mkdtemp()
         checkout_dir = extract_github_commit(working_dir, commit_url, commit_sha)
         built_dir = build_jekyll_site(checkout_dir)
-        zip = archive_commit(built_dir)
+        zip, bytes = archive_commit(built_dir)
         
     except Exception as e:
         logger.warning(e)
-        zip = None
+        zip, bytes = None, None
 
     finally:
         rmtree(working_dir)
     
-    return zip
+    return zip, bytes
 
 def extract_local_commit(work_dir, archive_path):
     '''
@@ -87,7 +87,7 @@ def extract_github_commit(work_dir, commit_url, commit_sha):
     return checkout_dir
 
 def archive_commit(directory):
-    ''' Pack directory into a zip archive, return zip object.
+    ''' Pack directory into a zip archive, return zip object and underlying BytesIO.
     '''
     content = BytesIO()
     zip = ZipFile(content, 'w', ZIP_DEFLATED)
@@ -100,4 +100,4 @@ def archive_commit(directory):
     
     print len(zip.namelist()), 'files in', len(content.getvalue()), 'bytes'
     
-    return zip
+    return zip, content

--- a/bizarro/publish/functions.py
+++ b/bizarro/publish/functions.py
@@ -14,40 +14,40 @@ from requests import get
 from ..jekyll_functions import build_jekyll_site
 
 def process_local_commit(archive_path):
-    ''' Return ZipFile and underlying file object.
+    ''' Return ZipFile.
     '''
     try:
         working_dir = mkdtemp()
         checkout_dir = extract_local_commit(working_dir, archive_path)
         built_dir = build_jekyll_site(checkout_dir)
-        zip, bytes = archive_commit(built_dir)
+        zip = archive_commit(built_dir)
         
     except Exception as e:
         logger.warning(e)
-        zip, bytes = None, None
+        zip = None
 
     finally:
         rmtree(working_dir)
     
-    return zip, bytes
+    return zip
 
 def process_remote_commit(commit_url, commit_sha):
-    ''' Return ZipFile and underlying file object.
+    ''' Return ZipFile.
     '''
     try:
         working_dir = mkdtemp()
         checkout_dir = extract_github_commit(working_dir, commit_url, commit_sha)
         built_dir = build_jekyll_site(checkout_dir)
-        zip, bytes = archive_commit(built_dir)
+        zip = archive_commit(built_dir)
         
     except Exception as e:
         logger.warning(e)
-        zip, bytes = None, None
+        zip = None
 
     finally:
         rmtree(working_dir)
     
-    return zip, bytes
+    return zip
 
 def extract_local_commit(work_dir, archive_path):
     '''
@@ -87,7 +87,7 @@ def extract_github_commit(work_dir, commit_url, commit_sha):
     return checkout_dir
 
 def archive_commit(directory):
-    ''' Pack directory into a zip archive, return zip object and underlying BytesIO.
+    ''' Pack directory into a zip archive, return zip object.
     '''
     content = BytesIO()
     zip = ZipFile(content, 'w', ZIP_DEFLATED)
@@ -100,4 +100,4 @@ def archive_commit(directory):
     
     print len(zip.namelist()), 'files in', len(content.getvalue()), 'bytes'
     
-    return zip, content
+    return zip

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -4,7 +4,6 @@ Logger = getLogger('bizarro.views')
 from os.path import join, isdir, splitext
 from re import compile, MULTILINE, sub
 from mimetypes import guess_type
-from urlparse import urljoin
 from glob import glob
 
 from git import Repo
@@ -251,10 +250,11 @@ def merge_branch():
         else:
             raise Exception('I do not know what "%s" means' % action)
 
-        build_url = urljoin(current_app.config['BROWSERID_URL'], '/builds/master.zip')
-        publish.announce_commit(build_url, r, r.commit().hexsha)
-        
-        #publish.release_commit(current_app.config['RUNNING_STATE_DIR'], r, r.commit().hexsha)
+        if current_app.config['PUBLISH_SERVICE_URL']:
+            publish.announce_commit(current_app.config['BROWSERID_URL'], r, r.commit().hexsha)
+
+        else:
+            publish.release_commit(current_app.config['RUNNING_STATE_DIR'], r, r.commit().hexsha)
 
     except repo_functions.MergeConflict as conflict:
         new_files, gone_files, changed_files = conflict.files()
@@ -301,15 +301,15 @@ def review_branch():
 
         return redirect('/tree/%s/edit/' % safe_branch, code=303)
 
-@app.route('/builds/<build>.zip')
+@app.route('/checkouts/<ref>.zip')
 @login_required
 @synch_required
-def get_branch_build(build):
+def get_checkout(ref):
     '''
     '''
     r = get_repo(current_app)
 
-    bytes = publish.retrieve_commit_build(current_app.config['RUNNING_STATE_DIR'], r, build)
+    bytes = publish.retrieve_commit_checkout(current_app.config['RUNNING_STATE_DIR'], r, ref)
     
     return Response(bytes.getvalue(), mimetype='application/zip')
 

--- a/env.sample
+++ b/env.sample
@@ -26,3 +26,6 @@ GA_REDIRECT_URI="http://127.0.0.1:5000/callback"
 #   
 #   # Optional URL base for live running website.
 #   LIVE_SITE_URL="http://127.0.0.1:5001/"
+#   
+#   # Used to push builds to a remote server
+#   PUBLISH_SERVICE_URL="http://example.org/"


### PR DESCRIPTION
Made possible to configure `PUBLISH_SERVICE_URL` for a remote location to receive publication notifications, but have not implemented it yet.

Closes #43, leads to #163.