### PR TITLE
created branch_required decorator to enforce new branches with post only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 *.pyc
+apache
 venv-*
 sample-site
 repo-*%40*

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -1,5 +1,6 @@
-import os, logging
-from os import environ, mkdir
+import os
+import logging
+from os import mkdir
 from os.path import join, split, exists, isdir
 from itertools import chain
 

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -63,7 +63,7 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
 
     return None
 
-def start_branch(clone, default_branch_name, new_branch_name):
+def get_start_branch(clone, default_branch_name, new_branch_name):
     ''' Start a new repository branch, push it to origin and return it.
 
         Don't touch the working directory. If an existing branch is found

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -3,6 +3,7 @@ import logging
 from os import mkdir
 from os.path import join, split, exists, isdir
 from itertools import chain
+from git.cmd import GitCommandError
 
 class MergeConflict (Exception):
     def __init__(self, remote_commit, local_commit):
@@ -52,6 +53,15 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
     if new_branch_name in clone.branches:
         if clone.branches[new_branch_name].commit == start_point:
             return clone.branches[new_branch_name]
+
+    # If the branch exists at the origin, check it out and return it
+    try:
+        clone.git.checkout(new_branch_name)
+        clone.git.pull('origin', new_branch_name)
+        return clone.branches[new_branch_name]
+
+    except GitCommandError:
+        return None
 
     return None
 

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -27,7 +27,7 @@ def _origin(branch_name):
     return 'origin/' + branch_name
 
 def get_branch_start_point(clone, default_branch_name, new_branch_name):
-    ''' Return the last commit on the appropriate branch
+    ''' Return the last commit on the branch
     '''
     clone.git.fetch('origin')
 
@@ -46,7 +46,6 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
 
     start_point = get_branch_start_point(clone, default_branch_name, new_branch_name)
 
-    # Start or update the branch, letting origin override the local repo.
     logging.debug('get_existing_branch() start_point is %s' % repr(start_point))
 
     # See if it already matches start_point
@@ -68,7 +67,7 @@ def start_branch(clone, default_branch_name, new_branch_name):
     if existing_branch:
         return existing_branch
 
-    # no existing branch, create and return a brand new branch
+    # create and return a brand new branch
     start_point = get_branch_start_point(clone, default_branch_name, new_branch_name)
     branch = clone.create_head(new_branch_name, commit=start_point, force=True)
     clone.git.push('origin', new_branch_name)

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -30,8 +30,6 @@ def _origin(branch_name):
 def get_branch_start_point(clone, default_branch_name, new_branch_name):
     ''' Return the last commit on the branch
     '''
-    clone.git.fetch('origin')
-
     if _origin(new_branch_name) in clone.refs:
         return clone.refs[_origin(new_branch_name)].commit
 
@@ -71,8 +69,6 @@ def start_branch(clone, default_branch_name, new_branch_name):
         Don't touch the working directory. If an existing branch is found
         with the same name, use it instead of creating a fresh branch.
     '''
-    clone.git.fetch('origin')
-
     existing_branch = get_existing_branch(clone, default_branch_name, new_branch_name)
     if existing_branch:
         return existing_branch

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -52,10 +52,13 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
         if clone.branches[new_branch_name].commit == start_point:
             return clone.branches[new_branch_name]
 
-    # If the branch exists at the origin, check it out and return it
+    # See if the branch exists at the origin
     try:
+        # pull the branch but keep the active branch checked out
+        active_branch = clone.active_branch
         clone.git.checkout(new_branch_name)
         clone.git.pull('origin', new_branch_name)
+        clone.git.checkout(active_branch.name)
         return clone.branches[new_branch_name]
 
     except GitCommandError:

--- a/bizarro/repo_functions.py
+++ b/bizarro/repo_functions.py
@@ -7,16 +7,16 @@ class MergeConflict (Exception):
     def __init__(self, remote_commit, local_commit):
         self.remote_commit = remote_commit
         self.local_commit = local_commit
-    
+
     def files(self):
         diffs = self.remote_commit.diff(self.local_commit)
 
         new_files = [d.b_blob.name for d in diffs if d.new_file]
         gone_files = [d.a_blob.name for d in diffs if d.deleted_file]
         changed_files = [d.a_blob.name for d in diffs if not (d.deleted_file or d.new_file)]
-        
+
         return new_files, gone_files, changed_files
-    
+
     def __str__(self):
         return 'MergeConflict(%s, %s)' % (self.remote_commit, self.local_commit)
 
@@ -25,19 +25,19 @@ def _origin(branch_name):
 
 def start_branch(clone, default_branch_name, new_branch_name):
     ''' Start a new repository branch, push it to origin and return it.
-    
+
         Don't touch the working directory. If an existing branch is found
         with the same name, use it instead of creating a fresh branch.
     '''
     clone.git.fetch('origin')
-    
+
     if _origin(new_branch_name) in clone.refs:
         start_point = clone.refs[_origin(new_branch_name)].commit
     elif _origin(default_branch_name) in clone.refs:
         start_point = clone.refs[_origin(default_branch_name)].commit
     else:
         start_point = clone.branches[default_branch_name].commit
-    
+
     # Start or update the branch, letting origin override the local repo.
     logging.debug('start_branch() start_point is %s' % repr(start_point))
 
@@ -48,28 +48,28 @@ def start_branch(clone, default_branch_name, new_branch_name):
 
     branch = clone.create_head(new_branch_name, commit=start_point, force=True)
     clone.git.push('origin', new_branch_name)
-    
+
     return branch
 
 def complete_branch(clone, default_branch_name, working_branch_name):
     ''' Complete a branch merging, deleting it, and returning the merge commit.
-    
+
         Checks out the default branch, merges the working branch in.
         Deletes the working branch in the clone and the origin, and leaves
         the working directory checked out to the merged default branch.
-        
+
         In case of merge error, leaves the working directory checked out
         to the original working branch.
-        
+
         Old behavior:
-    
+
         Checks out the working branch, merges the default branch in, then
         switches to the default branch and merges the working branch back.
         Deletes the working branch in the clone and the origin, and leaves
         the working directory checked out to the merged default branch.
     '''
     message = 'Merged work from "%s"' % working_branch_name
-    
+
     clone.git.checkout(default_branch_name)
     clone.git.pull('origin', default_branch_name)
 
@@ -89,15 +89,15 @@ def complete_branch(clone, default_branch_name, working_branch_name):
 
     else:
         clone.git.push('origin', default_branch_name)
-    
+
     #
     # Delete the working branch.
     #
     clone.remotes.origin.push(':' + working_branch_name)
     clone.delete_head([working_branch_name])
-    
+
     return clone.commit()
-    
+
     # #
     # # First, merge the default branch to the working branch.
     # #
@@ -123,7 +123,7 @@ def complete_branch(clone, default_branch_name, working_branch_name):
     # clone.git.checkout(default_branch_name)
     # clone.git.merge(working_branch_name)
     # clone.git.push('origin', default_branch_name)
-    # 
+    #
     # #
     # # Delete the working branch.
     # #
@@ -134,18 +134,18 @@ def abandon_branch(clone, default_branch_name, working_branch_name):
     ''' Complete work on a branch by abandoning and deleting it.
     '''
     msg = 'Abandoned work from "%s"' % working_branch_name
-    
+
     #
     # Add an empty commit with abandonment note.
     #
     clone.branches[default_branch_name].checkout()
     clone.index.commit(msg)
-    
+
     #
     # Delete the old branch.
     #
     clone.remotes.origin.push(':' + working_branch_name)
-    
+
     if working_branch_name in clone.branches:
         clone.git.branch('-D', working_branch_name)
 
@@ -153,7 +153,7 @@ def clobber_default_branch(clone, default_branch_name, working_branch_name):
     ''' Complete work on a branch by clobbering master and deleting it.
     '''
     msg = 'Clobbered with work from "%s"' % working_branch_name
-    
+
     #
     # First merge default to working branch, because
     # git does not provide a "theirs" strategy.
@@ -161,12 +161,12 @@ def clobber_default_branch(clone, default_branch_name, working_branch_name):
     clone.branches[working_branch_name].checkout()
     clone.git.fetch('origin', default_branch_name)
     clone.git.merge('FETCH_HEAD', '--no-ff', s='ours', m=msg) # "ours" = working
-    
+
     clone.branches[default_branch_name].checkout()
     clone.git.pull('origin', default_branch_name)
     clone.git.merge(working_branch_name, '--ff-only')
     clone.git.push('origin', default_branch_name)
-    
+
     #
     # Delete the working branch.
     #
@@ -175,50 +175,50 @@ def clobber_default_branch(clone, default_branch_name, working_branch_name):
 
 def make_working_file(clone, dir, path):
     ''' Create a new working file, return its local git and real absolute paths.
-    
+
         Creates a new file under the given directory, building whatever
         intermediate directories are necessary to write the file.
     '''
     repo_path = join((dir or '').rstrip('/'), path)
     real_path = join(clone.working_dir, repo_path)
-    
+
     #
     # Build a full directory path.
     #
     head, dirs = split(repo_path)[0], []
-    
+
     while head:
         head, dir = split(head)
         dirs.insert(0, dir)
-    
+
     if '..' in dirs:
         raise Exception('None of that now')
-        
+
     #
     # Create directory tree.
     #
     stuff = []
-    
+
     for i in range(len(dirs)):
         dir_path = join(clone.working_dir, os.sep.join(dirs[:i+1]))
-        
+
         if not isdir(dir_path):
             mkdir(dir_path)
-    
+
     return repo_path, real_path
 
 def save_working_file(clone, path, message, base_sha, default_branch_name):
     ''' Save a file in the working dir, push it to origin, return the commit.
-    
+
         Rely on Git environment variables for author emails and names.
-        
+
         After committing the new file, attempts to merge the origin working
         branch and the origin default branches in turn, to surface possible
         merge problems early. Might raise a MergeConflict.
     '''
     if clone.active_branch.commit.hexsha != base_sha:
         raise Exception('Out of date SHA: %s' % base_sha)
-    
+
     if exists(join(clone.working_dir, path)):
         clone.index.add([path])
     else:
@@ -226,7 +226,7 @@ def save_working_file(clone, path, message, base_sha, default_branch_name):
 
     clone.index.commit(message)
     active_branch_name = clone.active_branch.name
-    
+
     #
     # Sync with the default and upstream branches in case someone made a change.
     #
@@ -245,27 +245,27 @@ def save_working_file(clone, path, message, base_sha, default_branch_name):
             raise MergeConflict(remote_commit, clone.commit())
 
     clone.git.push('origin', active_branch_name)
-    
+
     return clone.active_branch.commit
 
 def move_existing_file(clone, old_path, new_path, base_sha, default_branch_name):
     ''' Move a file in the working dir, push it to origin, return the commit.
-    
+
         Rely on Git environment variables for author emails and names.
-        
+
         After committing the new file, attempts to merge the origin working
         branch and the origin default branches in turn, to surface possible
         merge problems early. Might raise a MergeConflict.
     '''
     if clone.active_branch.commit.hexsha != base_sha:
         raise Exception('Out of date SHA: %s' % base_sha)
-    
+
     new_repo_path, new_real_path = make_working_file(clone, '', new_path)
     clone.git.mv(old_path, new_path, f=True)
-    
+
     clone.index.commit('Renamed "%s" to "%s"' % (old_path, new_path))
     active_branch_name = clone.active_branch.name
-    
+
     #
     # Sync with the default and upstream branches in case someone made a change.
     #
@@ -284,7 +284,7 @@ def move_existing_file(clone, old_path, new_path, base_sha, default_branch_name)
             raise MergeConflict(remote_commit, clone.commit())
 
     clone.git.push('origin', active_branch_name)
-    
+
     return clone.active_branch.commit
 
 def needs_peer_review(repo, default_branch_name, working_branch_name):
@@ -292,10 +292,10 @@ def needs_peer_review(repo, default_branch_name, working_branch_name):
     '''
     base_commit = repo.git.merge_base(default_branch_name, working_branch_name)
     last_commit = repo.branches[working_branch_name].commit.hexsha
-    
+
     if base_commit == last_commit:
         return False
-    
+
     return not is_peer_approved(repo, default_branch_name, working_branch_name) \
        and not is_peer_rejected(repo, default_branch_name, working_branch_name)
 
@@ -304,7 +304,7 @@ def ineligible_peer(repo, default_branch_name, working_branch_name):
     '''
     if needs_peer_review(repo, default_branch_name, working_branch_name):
         return repo.branches[working_branch_name].commit.author.email
-    
+
     return None
 
 def is_peer_approved(repo, default_branch_name, working_branch_name):
@@ -312,21 +312,21 @@ def is_peer_approved(repo, default_branch_name, working_branch_name):
     '''
     base_commit = repo.git.merge_base(default_branch_name, working_branch_name)
     last_commit = repo.branches[working_branch_name].commit
-    
+
     if 'Approved changes.' not in last_commit.message:
         # To do: why does "commit: " get prefixed to the message?
         return False
-    
+
     reviewer_email = last_commit.author.email
     commit_log = last_commit.iter_parents() # reversed(repo.branches[working_branch_name].log())
-    
+
     for commit in commit_log:
         if commit == base_commit:
             break
-        
+
         if reviewer_email and commit.author.email != reviewer_email:
             return True
-    
+
     return False
 
 def is_peer_rejected(repo, default_branch_name, working_branch_name):
@@ -334,21 +334,21 @@ def is_peer_rejected(repo, default_branch_name, working_branch_name):
     '''
     base_commit = repo.git.merge_base(default_branch_name, working_branch_name)
     last_commit = repo.branches[working_branch_name].commit
-    
+
     if 'Provided feedback.' not in last_commit.message:
         # To do: why does "commit: " get prefixed to the message?
         return False
-    
+
     reviewer_email = last_commit.author.email
     commit_log = last_commit.iter_parents() # reversed(repo.branches[working_branch_name].log())
-    
+
     for commit in commit_log:
         if commit == base_commit:
             break
-        
+
         if reviewer_email and commit.author.email != reviewer_email:
             return True
-    
+
     return False
 
 def mark_as_reviewed(clone):
@@ -356,7 +356,7 @@ def mark_as_reviewed(clone):
     '''
     clone.index.commit('Approved changes.')
     active_branch_name = clone.active_branch.name
-    
+
     #
     # Sync with the default and upstream branches in case someone made a change.
     #
@@ -375,7 +375,7 @@ def mark_as_reviewed(clone):
             raise MergeConflict(remote_commit, clone.commit())
 
     clone.git.push('origin', active_branch_name)
-    
+
     return clone.active_branch.commit
 
 def provide_feedback(clone, comments):
@@ -383,7 +383,7 @@ def provide_feedback(clone, comments):
     '''
     clone.index.commit('Provided feedback.\n\n' + comments)
     active_branch_name = clone.active_branch.name
-    
+
     #
     # Sync with the default and upstream branches in case someone made a change.
     #
@@ -402,22 +402,22 @@ def provide_feedback(clone, comments):
             raise MergeConflict(remote_commit, clone.commit())
 
     clone.git.push('origin', active_branch_name)
-    
+
     return clone.active_branch.commit
 
 def get_rejection_messages(repo, default_branch_name, working_branch_name):
-    ''' 
+    '''
     '''
     messages = []
 
     base_commit = repo.git.merge_base(default_branch_name, working_branch_name)
     last_commit = repo.branches[working_branch_name].commit
     commit_log = chain([last_commit], last_commit.iter_parents())
-    
+
     for commit in commit_log:
         if commit.hexsha == base_commit:
             break
-        
+
         if 'Provided feedback.' in commit.message:
             email = commit.author.email
             message = commit.message[commit.message.index('Provided feedback.'):][len('Provided feedback.'):]

--- a/bizarro/view_functions.py
+++ b/bizarro/view_functions.py
@@ -15,7 +15,7 @@ import re
 from git import Repo, Git
 from dateutil import parser, tz
 from dateutil.relativedelta import relativedelta
-from flask import request, session, current_app, redirect
+from flask import request, session, current_app, redirect, flash
 from requests import get
 
 from .repo_functions import start_branch
@@ -358,10 +358,11 @@ def branch_required(route_function):
             repo.git.fetch('origin', with_exceptions=True)
 
         if branch_var2name(kwargs.get('branch', '')) in repo.refs:
-            Logger.debug('  branch {} does not exist, redirecting'.format(kwargs.get('branch', '')))
             return route_function(*args, **kwargs)
 
         # TODO: this should refer the user back to the url they came from
+        Logger.debug('  branch {} does not exist, redirecting'.format(kwargs.get('branch', '')))
+        flash(u'There is no {} branch!'.format(kwargs.get('branch', '')), u'warning')
         return redirect('/')
 
     return decorated_function

--- a/bizarro/view_functions.py
+++ b/bizarro/view_functions.py
@@ -345,6 +345,26 @@ def synch_required(route_function):
 
     return decorated_function
 
+def branch_required(route_function):
+    ''' Decorator for routes needing to have a branch exist
+
+    '''
+    @wraps(route_function)
+    def decorated_function(*args, **kwargs):
+        repo = Repo(current_app.config['REPO_PATH'])
+
+        if _remote_exists(repo, 'origin'):
+            repo.git.fetch('origin', with_exceptions=True)
+            print kwargs.get('branch_name')
+
+        if branch_var2name(kwargs.get('branch', '')) in repo.refs:
+            return route_function(*args, **kwargs)
+
+        # TODO: this should refer the user back to the url they came from
+        return redirect('/')
+
+    return decorated_function
+
 def synched_checkout_required(route_function):
     ''' Decorator for routes needing a repository checked out to a branch.
 

--- a/bizarro/view_functions.py
+++ b/bizarro/view_functions.py
@@ -352,7 +352,6 @@ def branch_required(route_function):
     @wraps(route_function)
     def decorated_function(*args, **kwargs):
         repo = Repo(current_app.config['REPO_PATH'])
-
         if _remote_exists(repo, 'origin'):
             Logger.debug('  fetching origin {}'.format(repo))
             repo.git.fetch('origin', with_exceptions=True)

--- a/bizarro/view_functions.py
+++ b/bizarro/view_functions.py
@@ -365,8 +365,8 @@ def synched_checkout_required(route_function):
         master_name = current_app.config['default_branch']
         branch = get_existing_branch(checkout, master_name, branch_name)
 
-        # redirect and flash an error if the branch wasn't found
         if not branch:
+            # redirect and flash an error
             Logger.debug('  branch {} does not exist, redirecting'.format(kwargs['branch']))
             flash(u'There is no {} branch!'.format(kwargs['branch']), u'warning')
             return redirect('/')

--- a/bizarro/view_functions.py
+++ b/bizarro/view_functions.py
@@ -354,10 +354,11 @@ def branch_required(route_function):
         repo = Repo(current_app.config['REPO_PATH'])
 
         if _remote_exists(repo, 'origin'):
+            Logger.debug('  fetching origin {}'.format(repo))
             repo.git.fetch('origin', with_exceptions=True)
-            print kwargs.get('branch_name')
 
         if branch_var2name(kwargs.get('branch', '')) in repo.refs:
+            Logger.debug('  branch {} does not exist, redirecting'.format(kwargs.get('branch', '')))
             return route_function(*args, **kwargs)
 
         # TODO: this should refer the user back to the url they came from

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -220,7 +220,7 @@ def start_branch():
     branch_desc = request.form.get('branch')
     branch_name = name_branch(branch_desc)
     master_name = current_app.config['default_branch']
-    branch = repo_functions.start_branch(r, master_name, branch_name)
+    branch = repo_functions.get_start_branch(r, master_name, branch_name)
 
     safe_branch = branch_name2path(branch.name)
     return redirect('/tree/%s/edit/' % safe_branch, code=303)

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -223,7 +223,7 @@ def start_branch():
     branch = repo_functions.get_start_branch(r, master_name, branch_name)
 
     safe_branch = branch_name2path(branch.name)
-    return redirect('/tree/%s/edit/' % safe_branch, code=303)
+    return redirect('/tree/{}/edit/'.format(safe_branch), code=303)
 
 @app.route('/merge', methods=['POST'])
 @login_required

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -19,7 +19,7 @@ from .view_functions import (
     branch_name2path, branch_var2name, get_repo, name_branch, dos2unix,
     login_required, synch_required, synched_checkout_required, sorted_paths,
     directory_paths, should_redirect, make_redirect, get_auth_data_file,
-    is_allowed_email, relative_datetime_string, common_template_args
+    is_allowed_email, relative_datetime_string, common_template_args, branch_required
     )
 from .google_api_functions import (
     read_ga_config, write_ga_config, request_new_google_access_and_refresh_tokens,
@@ -85,7 +85,7 @@ def index():
 def not_allowed():
     email = session.get('email', None)
     auth_data_href = current_app.config['AUTH_DATA_HREF']
-    
+
     kwargs = common_template_args(current_app.config, session)
     kwargs.update(auth_url=auth_data_href)
 
@@ -310,12 +310,13 @@ def get_checkout(ref):
     r = get_repo(current_app)
 
     bytes = publish.retrieve_commit_checkout(current_app.config['RUNNING_STATE_DIR'], r, ref)
-    
+
     return Response(bytes.getvalue(), mimetype='application/zip')
 
 @app.route('/tree/<branch>/view/', methods=['GET'])
 @app.route('/tree/<branch>/view/<path:path>', methods=['GET'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_view(branch, path=None):
     r = get_repo(current_app)
@@ -340,6 +341,7 @@ def branch_view(branch, path=None):
 @app.route('/tree/<branch>/edit/', methods=['GET'])
 @app.route('/tree/<branch>/edit/<path:path>', methods=['GET'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_edit(branch, path=None):
     branch = branch_var2name(branch)
@@ -413,6 +415,7 @@ def branch_edit(branch, path=None):
 @app.route('/tree/<branch>/edit/', methods=['POST'])
 @app.route('/tree/<branch>/edit/<path:path>', methods=['POST'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_edit_file(branch, path=None):
     r = get_repo(current_app)
@@ -454,6 +457,7 @@ def branch_edit_file(branch, path=None):
 @app.route('/tree/<branch>/history/', methods=['GET'])
 @app.route('/tree/<branch>/history/<path:path>', methods=['GET'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_history(branch, path=None):
     branch = branch_var2name(branch)
@@ -491,6 +495,7 @@ def branch_history(branch, path=None):
 
 @app.route('/tree/<branch>/review/', methods=['GET'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_review(branch):
     branch = branch_var2name(branch)
@@ -506,6 +511,7 @@ def branch_review(branch):
 
 @app.route('/tree/<branch>/save/<path:path>', methods=['POST'])
 @login_required
+@branch_required
 @synch_required
 def branch_save(branch, path):
     branch = branch_var2name(branch)

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -19,15 +19,11 @@ from .view_functions import (
     branch_name2path, branch_var2name, get_repo, name_branch, dos2unix,
     login_required, synch_required, synched_checkout_required, sorted_paths,
     directory_paths, should_redirect, make_redirect, get_auth_data_file,
-    is_allowed_email, relative_datetime_string, common_template_args, branch_required
-    )
+    is_allowed_email, relative_datetime_string, common_template_args, branch_required)
 from .google_api_functions import (
     read_ga_config, write_ga_config, request_new_google_access_and_refresh_tokens,
     authorize_google, get_google_personal_info, get_google_analytics_properties,
-    fetch_google_analytics_for_page, GA_CONFIG_FILENAME
-    )
-
-import json
+    fetch_google_analytics_for_page)
 
 @app.route('/')
 @login_required

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -415,7 +415,6 @@ def branch_edit(branch, path=None):
 @app.route('/tree/<branch>/edit/', methods=['POST'])
 @app.route('/tree/<branch>/edit/<path:path>', methods=['POST'])
 @login_required
-@branch_required
 @synched_checkout_required
 def branch_edit_file(branch, path=None):
     r = get_repo(current_app)
@@ -511,7 +510,6 @@ def branch_review(branch):
 
 @app.route('/tree/<branch>/save/<path:path>', methods=['POST'])
 @login_required
-@branch_required
 @synch_required
 def branch_save(branch, path):
     branch = branch_var2name(branch)

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -415,6 +415,7 @@ def branch_edit(branch, path=None):
 @app.route('/tree/<branch>/edit/', methods=['POST'])
 @app.route('/tree/<branch>/edit/<path:path>', methods=['POST'])
 @login_required
+@branch_required
 @synched_checkout_required
 def branch_edit_file(branch, path=None):
     r = get_repo(current_app)
@@ -510,6 +511,7 @@ def branch_review(branch):
 
 @app.route('/tree/<branch>/save/<path:path>', methods=['POST'])
 @login_required
+@branch_required
 @synch_required
 def branch_save(branch, path):
     branch = branch_var2name(branch)

--- a/test/test.py
+++ b/test/test.py
@@ -1400,9 +1400,60 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/edit/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/tree/{}/edit'.format(fake_branch_name) in response.data)
+            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
             # the branch name should not be in git's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
+
+            response = self.test_client.get('/tree/{}/history/'.format(fake_branch_name), follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+            # the branch path should not be in the returned HTML
+            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            # the branch name should not be in git's branches list
+            self.assertFalse(fake_branch_name in self.origin.branches)
+
+            response = self.test_client.get('/tree/{}/review/'.format(fake_branch_name), follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+            # the branch path should not be in the returned HTML
+            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            # the branch name should not be in git's branches list
+            self.assertFalse(fake_branch_name in self.origin.branches)
+
+            response = self.test_client.get('/tree/{}/view/'.format(fake_branch_name), follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+            # the branch path should not be in the returned HTML
+            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            # the branch name should not be in git's branches list
+            self.assertFalse(fake_branch_name in self.origin.branches)
+
+            # some POSTs should also not create new branches if they don't already exist
+
+            response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+            # the branch path should not be in the returned HTML
+            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            # the branch name should not be in git's branches list
+            self.assertFalse(fake_branch_name in self.origin.branches)
+
+            # create a branch then delete it right before a POSTing a save command
+            # response = self.test_client.post('/start', data={'branch': fake_branch_name}, follow_redirects=True)
+
+            # response = self.test_client.post('/tree/erica@example.com%252F{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
+            # self.assertEquals(response.status_code, 200)
+
+            # response = self.test_client.get('/tree/erica@example.com%252F{}/edit/'.format(fake_branch_name), follow_redirects=True)
+            # self.assertTrue('hello.html' in response.data)
+
+            # response = self.test_client.get('/tree/erica@example.com%252F{}/edit/hello.html'.format(fake_branch_name))
+            # hexsha = search(r'<input name="hexsha" value="(\w+)"', response.data).group(1)
+
+            # repo_functions.abandon_branch(self.origin, 'master', fake_branch_name)
+
+            # response = self.test_client.post('/tree/erica@example.com%252F{}/save/hello.html'.format(fake_branch_name), data={'layout': 'multi', 'hexsha': hexsha, 'en-title': 'Greetings', 'en-body': 'Hello world.\n', 'fr-title': '', 'fr-body': '', 'url-slug': 'hello'}, follow_redirects=True)            
+            # self.assertEqual(response.status_code, 200)
+            # # the branch path should not be in the returned HTML
+            # self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            # # the branch name should not be in git's branches list
+            # self.assertFalse(fake_branch_name in self.origin.branches)
 
     def test_google_callback_is_successful(self):
         ''' Ensure we get a successful page load on callback from Google authentication

--- a/test/test.py
+++ b/test/test.py
@@ -1181,6 +1181,7 @@ class TestApp (TestCase):
         self.origin = Repo(temp_repo_path)
 
         self.clone1 = self.origin.clone(mkdtemp(prefix='bizarro-'))
+        self.clone2 = self.origin.clone(mkdtemp(prefix='bizarro-'))
 
         app_args = {}
 
@@ -1215,6 +1216,7 @@ class TestApp (TestCase):
         rmtree(self.ga_config_dir)
         rmtree(self.origin.git_dir)
         rmtree(self.clone1.working_dir)
+        rmtree(self.clone2.working_dir)
 
     def auth_csv_example_disallowed(self, url, request):
         if url.geturl() == 'http://example.com/auth.csv':
@@ -1485,13 +1487,6 @@ class TestApp (TestCase):
             self.assertFalse('/erica@example.com/{}'.format(fake_branch_name) in response.data)
             # the branch name should not be in git's branches list
             self.assertFalse('erica@example.com/{}'.format(fake_branch_name) in self.origin.branches)
-
-    def test_accessing_local_branch_fetches_remote(self):
-        ''' GETting or POSTing to a URL that indicates a branch that exists remotely but not locally
-            fetches the remote branch and allows access
-        '''
-        pass
-        # ;;;
 
     def test_google_callback_is_successful(self):
         ''' Ensure we get a successful page load on callback from Google authentication

--- a/test/test.py
+++ b/test/test.py
@@ -1400,6 +1400,9 @@ class TestApp (TestCase):
 
         with HTTMock(self.auth_csv_example_allowed):
             fake_branch_name = 'this-should-not-create-a-branch'
+            #
+            # edit
+            #
             response = self.test_client.get('/tree/{}/edit/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
@@ -1407,6 +1410,9 @@ class TestApp (TestCase):
             # the branch name should not be in git's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
+            #
+            # history
+            #
             response = self.test_client.get('/tree/{}/history/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
@@ -1414,6 +1420,9 @@ class TestApp (TestCase):
             # the branch name should not be in git's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
+            #
+            # review
+            #
             response = self.test_client.get('/tree/{}/review/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
@@ -1421,6 +1430,9 @@ class TestApp (TestCase):
             # the branch name should not be in git's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
+            #
+            # view
+            #
             response = self.test_client.get('/tree/{}/view/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
@@ -1435,9 +1447,9 @@ class TestApp (TestCase):
             self.test_client.post('/sign-in', data={'email': 'erica@example.com'})
 
         with HTTMock(self.auth_csv_example_allowed):
-
+            #
             # try adding a new file
-
+            #
             fake_branch_name = 'this-should-not-create-a-branch'
             response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)

--- a/test/test.py
+++ b/test/test.py
@@ -1181,7 +1181,6 @@ class TestApp (TestCase):
         self.origin = Repo(temp_repo_path)
 
         self.clone1 = self.origin.clone(mkdtemp(prefix='bizarro-'))
-        self.clone2 = self.origin.clone(mkdtemp(prefix='bizarro-'))
 
         app_args = {}
 
@@ -1216,7 +1215,6 @@ class TestApp (TestCase):
         rmtree(self.ga_config_dir)
         rmtree(self.origin.git_dir)
         rmtree(self.clone1.working_dir)
-        rmtree(self.clone2.working_dir)
 
     def auth_csv_example_disallowed(self, url, request):
         if url.geturl() == 'http://example.com/auth.csv':
@@ -1408,8 +1406,8 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/edit/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
             #
@@ -1418,8 +1416,8 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/history/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
             #
@@ -1428,8 +1426,8 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/review/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
             #
@@ -1438,8 +1436,8 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/view/'.format(fake_branch_name), follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
     def test_post_request_does_not_create_branch(self):
@@ -1456,15 +1454,15 @@ class TestApp (TestCase):
             response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
             #
             # create a branch then delete it right before a POSTing a save command
             #
             response = self.test_client.post('/start', data={'branch': fake_branch_name}, follow_redirects=True)
-            self.assertTrue('erica@example.com/{}'.format(fake_branch_name) in response.data)
+            self.assertTrue('{}/edit'.format(fake_branch_name) in response.data)
 
             response = self.test_client.post('/tree/erica@example.com%252F{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
             self.assertEquals(response.status_code, 200)
@@ -1484,8 +1482,8 @@ class TestApp (TestCase):
             response = self.test_client.post('/tree/erica@example.com%252F{}/save/hello.html'.format(fake_branch_name), data={'layout': 'multi', 'hexsha': hexsha, 'en-title': 'Greetings', 'en-body': 'Hello world.\n', 'fr-title': '', 'fr-body': '', 'url-slug': 'hello'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/erica@example.com/{}'.format(fake_branch_name) in response.data)
-            # the branch name should not be in git's branches list
+            self.assertFalse('{}/edit'.format(fake_branch_name) in response.data)
+            # the branch name should not be in the origin's branches list
             self.assertFalse('erica@example.com/{}'.format(fake_branch_name) in self.origin.branches)
 
     def test_google_callback_is_successful(self):

--- a/test/test.py
+++ b/test/test.py
@@ -1476,12 +1476,13 @@ class TestApp (TestCase):
             hexsha = search(r'<input name="hexsha" value="(\w+)"', response.data).group(1)
 
             # delete the branch
-            response = self.test_client.post('/merge', data={'action': 'abandon', 'branch': 'erica@example.com/{}'.format(fake_branch_name)})
+            response = self.test_client.post('/merge', data={'action': 'abandon', 'branch': 'erica@example.com/{}'.format(fake_branch_name)}, follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
 
             response = self.test_client.post('/tree/erica@example.com%252F{}/save/hello.html'.format(fake_branch_name), data={'layout': 'multi', 'hexsha': hexsha, 'en-title': 'Greetings', 'en-body': 'Hello world.\n', 'fr-title': '', 'fr-body': '', 'url-slug': 'hello'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML
-            self.assertFalse('/{}'.format(fake_branch_name) in response.data)
+            self.assertFalse('/erica@example.com/{}'.format(fake_branch_name) in response.data)
             # the branch name should not be in git's branches list
             self.assertFalse('erica@example.com/{}'.format(fake_branch_name) in self.origin.branches)
 

--- a/test/test.py
+++ b/test/test.py
@@ -1425,8 +1425,15 @@ class TestApp (TestCase):
             # the branch name should not be in git's branches list
             self.assertFalse(fake_branch_name in self.origin.branches)
 
-            # some POSTs should also not create new branches if they don't already exist
+    def test_post_request_does_not_create_branch(self):
+        ''' Certain POSTs to a made-up URL should not create a branch
+        '''
 
+        with HTTMock(self.mock_persona_verify):
+            self.test_client.post('/sign-in', data={'email': 'erica@example.com'})
+
+        with HTTMock(self.auth_csv_example_allowed):
+            fake_branch_name = 'this-should-not-create-a-branch'
             response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': 'hello.html'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch path should not be in the returned HTML

--- a/test/test.py
+++ b/test/test.py
@@ -210,11 +210,11 @@ class TestRepo (TestCase):
         branch_names = [b.name for b in self.origin.branches]
         self.assertEqual(set(branch_names), set(['master', 'title', 'body']))
 
-    def test_start_branch(self):
+    def test_get_start_branch(self):
         ''' Make a simple edit in a clone, verify that it appears in the other.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertTrue(name in self.clone1.branches)
         self.assertTrue(name in self.origin.branches)
@@ -234,13 +234,13 @@ class TestRepo (TestCase):
         #
         # See if the branch made it to clone 2
         #
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         self.assertTrue(name in self.clone2.branches)
         self.assertEquals(branch2.commit.hexsha, branch1.commit.hexsha)
         self.assertEquals(branch2.commit.message, message)
 
-    def test_start_branch_2(self):
+    def test_get_start_branch_2(self):
         ''' Make a simple edit in a clone, verify that it appears in the other.
         '''
         name = str(uuid4())
@@ -270,7 +270,7 @@ class TestRepo (TestCase):
         #
         # Now start a branch from the second clone, and look for the new master commit.
         #
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         self.assertTrue(name in self.clone2.branches)
         self.assertEquals(branch2.commit.hexsha, self.origin.refs['master'].commit.hexsha)
@@ -280,7 +280,7 @@ class TestRepo (TestCase):
         '''
         name = str(uuid4())
 
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertTrue(name in self.origin.branches)
 
@@ -296,7 +296,7 @@ class TestRepo (TestCase):
         ''' Make a new file and delete an old file in a clone, verify that it appears in the other.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertTrue(name in self.clone1.branches)
         self.assertTrue(name in self.origin.branches)
@@ -325,7 +325,7 @@ class TestRepo (TestCase):
         #
         # See if the branch made it to clone 2
         #
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         self.assertTrue(name in self.clone2.branches)
         self.assertEquals(branch2.commit.hexsha, branch1.commit.hexsha)
@@ -347,7 +347,7 @@ class TestRepo (TestCase):
         ''' Make a new file and directory and delete them.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertTrue(name in self.clone1.branches)
         self.assertTrue(name in self.origin.branches)
@@ -383,7 +383,7 @@ class TestRepo (TestCase):
         ''' Change the path of a file.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertTrue(name in self.clone1.branches)
         self.assertTrue(name in self.origin.branches)
@@ -399,7 +399,7 @@ class TestRepo (TestCase):
         #
         # See if the new file made it to clone 2
         #
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
         branch2.checkout()
 
         self.assertTrue(exists(join(self.clone2.working_dir, 'hello/world.md')))
@@ -408,8 +408,8 @@ class TestRepo (TestCase):
     def test_content_merge(self):
         ''' Test that non-conflicting changes on the same file merge cleanly.
         '''
-        branch1 = repo_functions.start_branch(self.clone1, 'master', 'title')
-        branch2 = repo_functions.start_branch(self.clone2, 'master', 'body')
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', 'title')
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', 'body')
 
         branch1.checkout()
         branch2.checkout()
@@ -446,8 +446,8 @@ class TestRepo (TestCase):
     def test_content_merge_extra_change(self):
         ''' Test that non-conflicting changes on the same file merge cleanly.
         '''
-        branch1 = repo_functions.start_branch(self.clone1, 'master', 'title')
-        branch2 = repo_functions.start_branch(self.clone2, 'master', 'body')
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', 'title')
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', 'body')
 
         branch1.checkout()
         branch2.checkout()
@@ -492,8 +492,8 @@ class TestRepo (TestCase):
         ''' Test that two non-conflicting new files merge cleanly.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         #
         # Make new files in each branch and save them.
@@ -532,7 +532,7 @@ class TestRepo (TestCase):
         #
         # Show that the merge from the second branch made it back to the first.
         #
-        branch1b = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1b = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         self.assertEquals(branch1b.commit, branch2.commit)
         self.assertEquals(branch1b.commit.author.email, self.session['email'])
@@ -542,8 +542,8 @@ class TestRepo (TestCase):
         ''' Test that a conflict in two branches appears at the right spot.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         #
         # Make new files in each branch and save them.
@@ -585,8 +585,8 @@ class TestRepo (TestCase):
         ''' Test that a conflict in two branches appears at the right spot.
         '''
         name1, name2 = str(uuid4()), str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name1)
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name2)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name1)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name2)
 
         #
         # Make new files in each branch and save them.
@@ -634,8 +634,8 @@ class TestRepo (TestCase):
         ''' Test that a conflict in two branches appears at the right spot.
         '''
         name1, name2 = str(uuid4()), str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name1)
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name2)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name1)
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name2)
 
         #
         # Make new files in each branch and save them.
@@ -680,8 +680,8 @@ class TestRepo (TestCase):
         ''' Test that a conflict in two branches can be clobbered.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', 'title')
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', 'title')
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         #
         # Add goner.md in branch1.
@@ -742,8 +742,8 @@ class TestRepo (TestCase):
         ''' Test that a conflict in two branches can be abandoned.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', 'title')
-        branch2 = repo_functions.start_branch(self.clone2, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', 'title')
+        branch2 = repo_functions.get_start_branch(self.clone2, 'master', name)
 
         #
         # Change index.md in branch2 so it conflicts with title branch.
@@ -798,7 +798,7 @@ class TestRepo (TestCase):
         ''' Change the path of a file.
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         #
         # Make a commit.
@@ -867,7 +867,7 @@ class TestRepo (TestCase):
         '''
         '''
         name = str(uuid4())
-        branch1 = repo_functions.start_branch(self.clone1, 'master', name)
+        branch1 = repo_functions.get_start_branch(self.clone1, 'master', name)
 
         #
         # Make a commit.
@@ -1504,7 +1504,7 @@ class TestApp (TestCase):
             # create a branch programmatically on our pre-made clone
             check_branch_name = u'the-branch-we-are-checking-for'
             check_branch_name_full = 'erica@example.com/{}'.format(check_branch_name)
-            repo_functions.start_branch(self.clone1, 'master', check_branch_name_full)
+            repo_functions.get_start_branch(self.clone1, 'master', check_branch_name_full)
             self.assertTrue(check_branch_name_full in self.clone1.branches)
             self.assertTrue(check_branch_name_full in self.origin.branches)
             # verify that the branch doesn't exist in our new clone

--- a/test/test.py
+++ b/test/test.py
@@ -1180,6 +1180,8 @@ class TestApp (TestCase):
         copytree(repo_path, temp_repo_path)
         self.origin = Repo(temp_repo_path)
 
+        self.clone1 = self.origin.clone(mkdtemp(prefix='bizarro-'))
+
         app_args = {}
 
         app_args['SINGLE_USER'] = 'Yes'
@@ -1212,6 +1214,7 @@ class TestApp (TestCase):
         rmtree(self.work_path)
         rmtree(self.ga_config_dir)
         rmtree(self.origin.git_dir)
+        rmtree(self.clone1.working_dir)
 
     def auth_csv_example_disallowed(self, url, request):
         if url.geturl() == 'http://example.com/auth.csv':


### PR DESCRIPTION
### What Changed
+ Added a `@branch_required` decorator to ensure that you can't create branches by just navigating to them (see old screencap)
+ Cleaned up some rogue whitespace

### Issues
+ Fixes #147 

### Notes
+ Right now the implementation just redirects you back to `/`, but it might be nice to do a redirect-back. I'm not totally sure how to implement that though.
+ Are we doing flashes? If so, this should probably flash some sort of message.

### Screencap
**Old**
![fun-fun-fun-old](https://cloud.githubusercontent.com/assets/1957344/7196348/36c3bb4a-e485-11e4-8612-7797cc2c0585.gif)

**New**
![fun-fun-fun](https://cloud.githubusercontent.com/assets/1957344/7196353/39b2f2c6-e485-11e4-9ec9-eb12ee4e370b.gif)
